### PR TITLE
Feat/forum avatars: serve phpBB avatars via MEDIA_ROOT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ scratch
 __pycache__
 *.py[oc]
 db.sqlite3
+media
 
 # Ignore development files
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ scratch
 
 # Django
 staticfiles
+media

--- a/apps/forum/models.py
+++ b/apps/forum/models.py
@@ -64,6 +64,20 @@ class ForumUser(models.Model):
     registered_at = models.DateTimeField("Дата регистрации", null=True, blank=True)
     post_count = models.IntegerField("Количество сообщений", default=0)
 
+    @property
+    def avatar_url(self):
+        if not self.avatar:
+            return ""
+        if self.avatar.startswith(("http://", "https://")):
+            return self.avatar
+        import re
+
+        from django.conf import settings
+
+        # phpBB stored "5_1316512958.jpg" in DB but renamed file on disk to "5.jpg"
+        filename = re.sub(r"^(\d+)_\d+(\.\w+)$", r"\1\2", self.avatar)
+        return f"{settings.MEDIA_URL}forum/avatars/{filename}"
+
     class Meta:
         verbose_name = "Пользователь форума"
         verbose_name_plural = "Пользователи форума"

--- a/apps/forum/static/forum/css/forum.css
+++ b/apps/forum/static/forum/css/forum.css
@@ -236,9 +236,9 @@
   display:flex; align-items:center; justify-content:center;
   flex-shrink:0;
   font-size:16px; font-weight:700; color:var(--accent);
-  overflow:hidden; flex-shrink:0;
+  overflow:hidden;
+  object-fit:cover;
 }
-.post-avatar img{ width:100%; height:100%; object-fit:cover; }
 
 .post-thread-line{
   flex:1; width:2px; min-height:16px;

--- a/apps/forum/templates/forum/topic.html
+++ b/apps/forum/templates/forum/topic.html
@@ -33,10 +33,10 @@
       <div class="post-card">
         <div class="post-left">
           {% if post.author_username %}{% with dn=post.author_username %}
-            {% if post.author and post.author.avatar %}<img class="post-avatar" src="{{ post.author.avatar }}" alt="{{ dn }}">
+            {% if post.author and post.author.avatar_url %}<img class="post-avatar" src="{{ post.author.avatar_url }}" alt="{{ dn }}">
             {% else %}<div class="post-avatar">{{ dn|slice:":1"|upper }}</div>{% endif %}
           {% endwith %}{% elif post.author %}
-            {% if post.author.avatar %}<img class="post-avatar" src="{{ post.author.avatar }}" alt="{{ post.author.username }}">
+            {% if post.author.avatar_url %}<img class="post-avatar" src="{{ post.author.avatar_url }}" alt="{{ post.author.username }}">
             {% else %}<div class="post-avatar">{{ post.author.username|slice:":1"|upper }}</div>{% endif %}
           {% else %}
             <div class="post-avatar">—</div>

--- a/apps/forum/tests.py
+++ b/apps/forum/tests.py
@@ -69,6 +69,24 @@ class ForumUserModelTests(TestCase):
         self.assertEqual(user.avatar, "")
         self.assertIsNone(user.registered_at)
 
+    def test_avatar_url_empty(self):
+        user = ForumUser(avatar="")
+        self.assertEqual(user.avatar_url, "")
+
+    def test_avatar_url_local(self):
+        user = ForumUser(avatar="168.jpg")
+        self.assertIn("/forum/avatars/168.jpg", user.avatar_url)
+        self.assertTrue(user.avatar_url.startswith("/media/"))
+
+    def test_avatar_url_timestamp_format(self):
+        user = ForumUser(avatar="5_1316512958.jpg")
+        self.assertIn("/forum/avatars/5.jpg", user.avatar_url)
+
+    def test_avatar_url_remote(self):
+        url = "https://example.com/avatar.jpg"
+        user = ForumUser(avatar=url)
+        self.assertEqual(user.avatar_url, url)
+
 
 class TopicModelTests(TestCase):
     def setUp(self):

--- a/config/settings.py
+++ b/config/settings.py
@@ -156,6 +156,9 @@ USE_TZ = True
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,6 +15,8 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import RedirectView
@@ -26,4 +28,4 @@ urlpatterns = [
     path("contributors/", include("apps.contributors.urls")),
     path("accounts/", include("apps.accounts.urls")),
     path("forum/", include("apps.forum.urls")),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
- Configure MEDIA_URL/MEDIA_ROOT; serve in dev via static() in urls.py
- Add ForumUser.avatar_url property: handles local files, remote URLs, and normalises phpBB timestamp format (5_1316512958.jpg → 5.jpg)
- Fix post-avatar CSS: apply object-fit:cover directly to <img>
  (previous .post-avatar img selector never matched)
- Add media/ to .gitignore and .dockerignore